### PR TITLE
Run `mdl` in in the projectPath

### DIFF
--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,1 @@
+style '.style.rb'

--- a/.style.rb
+++ b/.style.rb
@@ -1,0 +1,3 @@
+all
+
+exclude_rule 'line-length'

--- a/README.md
+++ b/README.md
@@ -1,34 +1,38 @@
-linter-markdownlint
-=========================
+# linter-markdownlint
 
-This linter plugin for [Linter](https://github.com/AtomLinter/Linter) provides an interface to [markdownlint](https://github.com/mivok/markdownlint). It will be used with files that have the “Markdown” syntax.
+This linter plugin for [Linter](https://github.com/AtomLinter/Linter) provides an interface to [markdownlint](https://github.com/mivok/markdownlint). It will be used with files that have the "Markdown" syntax.
 
 ## Installation
+
 Linter package must be installed in order to use this plugin. If Linter is not installed, please follow the instructions [here](https://github.com/AtomLinter/Linter).
 
 ### mdl installation
+
 Before using this plugin, you must ensure that `mdl` is installed on your system. To install `mdl`, do the following:
 
 1. Install [ruby](https://www.ruby-lang.org/).
 
-2. Install [markdownlint](https://github.com/mivok/markdownlint) by typing the following in a terminal:
-   ```
-   gem install mdl
-   ```
+1. Install [markdownlint](https://github.com/mivok/markdownlint) by typing the following in a terminal:
 
-Now you can proceed to install the linter-markdownlint plugin.
+```sh
+gem install mdl
+```
+
+Now you can proceed to install the _linter-markdownlint_ plugin.
 
 ### Plugin installation
-```
-$ apm install linter-markdownlint
+
+```sh
+apm install linter-markdownlint
 ```
 
 ## Settings
-You can configure linter-markdownlint by editing ~/.atom/config.cson (choose Open Your Config in Atom menu):
 
-```
+You can configure _linter-markdownlint_ by editing ~/.atom/config.cson (choose _Config..._ in _Atom_ menu):
+
+```cson
 'linter-markdownlint':
   'executablePath': null # markdownlint executable path.
 ```
-Run `which mdl` to find the path,
-if you using rbenv run `rbenv which mdl`
+
+Run `which mdl` to find the path, if you using _rbenv_ run `rbenv which mdl`

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -47,8 +47,10 @@ module.exports =
       lint: (TextEditor) =>
         return new Promise (resolve, reject) =>
           filePath = TextEditor.getPath()
+          fileDir = atom.project.relativizePath(filePath)[0]
           lines = []
           process = new BufferedProcess
+            options: cwd: fileDir
             command: Command.getExecutablePath()
             args: [filePath]
             stdout: (data) ->

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "linter-markdownlint",
   "activationCommands": {},
   "main": "./lib/init",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Lint Markdown with mdl",
   "keywords": [
     "linter",


### PR DESCRIPTION
* Runs `mdl` in in the projectPath to use the right configuration (_.mdlrc_) settings. Fixes issue described by me in https://github.com/lloeki/linter-markdownlint/issues/4#issuecomment-3325
* Runs mdl against the README, includes a _.mdlrc_ and _.style.rb_
* Bumps version patch number for future release.